### PR TITLE
Adding Identifiable extensions for SwiftUI applications

### DIFF
--- a/Sources/KukaiCoreSwift/Models/Account.swift
+++ b/Sources/KukaiCoreSwift/Models/Account.swift
@@ -28,3 +28,9 @@ public struct Account: Codable, Hashable {
 	/// Can be set to false by BCD fetch all account info code. In this case it denotes that the inital queried data matched the previous inital data and no expensive update operations should be performed
 	public var changedSinceLastFetch: Bool = true
 }
+
+extension Account: Identifiable {
+	public var id: String {
+		walletAddress
+	}
+}

--- a/Sources/KukaiCoreSwift/Models/BakingBad/BetterCallDevTokenMetadata.swift
+++ b/Sources/KukaiCoreSwift/Models/BakingBad/BetterCallDevTokenMetadata.swift
@@ -13,7 +13,7 @@ public class BetterCallDevTokenMetadata: Codable {
 	
 	public let contract: String
 	public let network: String
-	public let token_id: Int
+	public let token_id: Decimal
 	public let symbol: String?
 	public let name: String?
 	public let decimals: Int?

--- a/Sources/KukaiCoreSwift/Models/NFT.swift
+++ b/Sources/KukaiCoreSwift/Models/NFT.swift
@@ -56,3 +56,9 @@ public struct NFT: Codable, Hashable {
 		thumbnailURI = URL(string: bcd.thumbnail_uri ?? "")
 	}
 }
+
+extension NFT: Identifiable {
+	public var id: String {
+		parentContract + String(tokenId)
+	}
+}

--- a/Sources/KukaiCoreSwift/Models/Token.swift
+++ b/Sources/KukaiCoreSwift/Models/Token.swift
@@ -66,6 +66,9 @@ public class Token: Codable, CustomStringConvertible {
 	
 	/// The individual NFT's owned of this token type
 	public var nfts: [NFT]?
+
+	/// Each token type on a contract will have a unique token_id
+	public var token_id: Decimal?
 	
 	
 	
@@ -143,8 +146,15 @@ extension Token: Hashable {
 extension Token: Identifiable {
 
 	/// Conforming to `Identifiable` to enable working with ForEach and similiar looping functions
-	/// `tokenContractAddress` will return empty for `XTZ` so we'll just use `tokenType` because it represents XTZ for my use case
-	public var id: String {
-		tokenContractAddress ?? tokenType.rawValue
-	}
+    /// `tokenContractAddress` will return empty for `XTZ` so we'll need to  use `symbol` and `tokenType` for more information
+    public var id: String {
+        guard let tokenContractAddress = tokenContractAddress,
+              var token_id = token_id else {
+                  return "\(symbol)_\(tokenType.rawValue)"
+              }
+
+		let unsafeTokenIDPointer = UnsafePointer<Decimal>(&token_id)
+        
+        return "\(tokenContractAddress)_\(symbol)_\(NSDecimalString(unsafeTokenIDPointer, Locale.current))"
+    }
 }

--- a/Sources/KukaiCoreSwift/Models/Token.swift
+++ b/Sources/KukaiCoreSwift/Models/Token.swift
@@ -139,3 +139,12 @@ extension Token: Hashable {
 		hasher.combine(tokenContractAddress)
 	}
 }
+
+extension Token: Identifiable {
+
+	/// Conforming to `Identifiable` to enable working with ForEach and similiar looping functions
+	/// `tokenContractAddress` will return empty for `XTZ` so we'll just use `tokenType` because it represents XTZ for my use case
+	public var id: String {
+		tokenContractAddress ?? tokenType.rawValue
+	}
+}


### PR DESCRIPTION
also updated `BetterCallDevTokenMetadata` `token_id` to use `Decimal` as opposed to `Int` to cover some new `OBJKT` NFTs with really large numbers